### PR TITLE
Add HTTP-API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,17 @@ Basically, the script logs in on your behalf, using a TLS client, then grabs the
 - [x] Saves the access token to a file, so you don't have to log in again
 - [x] Automatically refreshes the access token when it expires
 - [x] Uses colorama to colorize the output, because why not?
+- [x] HTTP API serving
 
 ### Shall we get started?
 1. Clone the repository
 2. Install the requirements using `pip install -r requirements.txt`
 3. Open `config.json` and enter your email and password.
-4. Run `main.py` and let the script do the rest.
+4. Run `main.py` and let the script do the rest.  
+5. *[optional]* To enable HTTP-API support:
+- Install uvicorn by running `pip install "uvicorn[standard]"`;
+- Start by running: `nohup uvicorn api:app --host 0.0.0.0 --reload > log.txt 2>&1 &`. ;
+- Then, access by `GET` method at `http://host:port/{prompt}`. 
 
 ### Other notes
 If the token creation process is failing, on `main.py` on line 40
@@ -33,8 +38,8 @@ If the token creation process is failing, on `main.py` on line 40
 ```python
 Auth.OpenAIAuth(email_address=email, password=password, use_proxy=True, proxy="http://127.0.0.0:8080")
 ```
-2. Don't try to log in too fast. At least wait 10 minutes if you're being rate limited.
-3. If you're still having issues, try to use a VPN. On a VPN, the script should work fine.
+2. Don't try to log in too fast. At least wait 10 minutes if you're being rate limited
+3. If you're still having issues, try to use a VPN. On a VPN, the script should work fine
 ### What's next?
 I'm planning to add a few more features, such as:
 - [ ] A GUI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tls-client
 requests~=2.27.1
+fastapi==0.88.0
 colorama~=0.4.4
 svglib~=1.4.1
 bs4~=0.0.1

--- a/webapi.py
+++ b/webapi.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Builtins
+import json
+import os
+import time
+
+# Local
+from Classes import auth as Auth
+from Classes import chat as Chat
+
+# Fancy stuff
+import colorama
+from colorama import Fore
+from typing import Union
+
+from fastapi import FastAPI
+
+AI_PREV_CONVO = None
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"Only accept:": "'host:port/{query}'"}
+
+
+@app.get("/{prompt}")
+def chatGPT(prompt: str, previous_convo: str = None) -> str:
+    global AI_PREV_CONVO
+    print(f"{Fore.GREEN}>> Starting chat..." + Fore.RESET)
+    access_token = Auth.get_access_token()
+    if access_token == "":
+        print(f"{Fore.RED}>> Access token is missing in /Classes/auth.json.")
+        pass
+    answer, previous_convo = Chat.ask(auth_token=access_token,
+                                      prompt=prompt,
+                                      previous_convo_id=AI_PREV_CONVO)
+    if answer == "400" or answer == "401":
+        result = ">> Token invalid, please contact the owner to refresh."
+        print(f"{Fore.RED}>> Your token is invalid. Attempting to refresh..")
+        pass
+    else:
+        result = answer
+        if previous_convo is not None:
+            AI_PREV_CONVO = previous_convo
+    print(result)
+    return result
+
+
+if __name__ == "__main__":
+    prompt = input("You: ")
+    print(chatGPT(prompt))


### PR DESCRIPTION
[x] Add HTTP-API support, with a simple format notice;
[x] Updated `requirements.txt`: `fastapi` added.
[x] Updated `READ.ME`: HTTP-API tutorial, including how to install `uvicron`.
[x] Local & remote nginx reverse-proxy test passed.

e.g.
```
IN: 
http(s)://host:port/how%20are%20you

OUT:
"I'm a machine learning model trained by OpenAI, so I don't have feelings or emotions like a human does. I'm designed to provide answers to questions to the best of my ability based on the information I've been trained on. Is there something specific you would like to know?”
```