### PR TITLE
fix: typo in Classes imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,9 +7,9 @@ import os
 import time
 
 # Local
-from classes import auth as Auth
-from classes import chat as Chat
-from classes import spinner as Spinner
+from Classes import auth as Auth
+from Classes import chat as Chat
+from Classes import spinner as Spinner
 
 # Fancy stuff
 import colorama


### PR DESCRIPTION
Hi Rawand,

Not sure about this fix, I had to correct this typo on my fresh ubuntu install in order to run `main.py`

Error displayed without this fix:

```
$ python3 main.py 
Traceback (most recent call last):
  File "/home/alx/code/PyChatGPT/main.py", line 10, in <module>
    from classes import auth as Auth
ModuleNotFoundError: No module named 'classes'
```

Thanks,

Alex