### PR TITLE
fix: typo in Classes path

### DIFF
--- a/Classes/auth.py
+++ b/Classes/auth.py
@@ -31,7 +31,7 @@ def expired_creds() -> bool:
             bool: True if expired, False if not
     """
     try:
-        # Get path using os, it's in ./classes/auth.json
+        # Get path using os, it's in ./Classes/auth.json
         path = os.path.dirname(os.path.abspath(__file__))
         path = os.path.join(path, "auth.json")
 
@@ -53,7 +53,7 @@ def get_access_token() -> str:
             str: The access token
     """
     try:
-        # Get path using os, it's in ./classes/auth.json
+        # Get path using os, it's in ./Classes/auth.json
         path = os.path.dirname(os.path.abspath(__file__))
         path = os.path.join(path, "auth.json")
 
@@ -359,7 +359,7 @@ class OpenAIAuth:
                 access_token = access_token[0]
                 access_token = access_token.split('"')[0]
                 print(f"{Fore.GREEN}[OpenAI][8] {Fore.WHITE}Access Token: {Fore.GREEN}{access_token}")
-                # Save access_token and an hour from now on ./classes/auth.json
+                # Save access_token and an hour from now on ./Classes/auth.json
                 self.save_access_token(access_token=access_token)
             else:
                 print(f"{Fore.RED}[OpenAI][8] {Fore.WHITE}While most of the process was successful, "
@@ -368,11 +368,11 @@ class OpenAIAuth:
     @staticmethod
     def save_access_token(access_token: str):
         """
-        Save access_token and an hour from now on ./classes/auth.json
+        Save access_token and an hour from now on ./Classes/auth.json
         :param access_token:
         :return:
         """
-        with open("classes/auth.json", "w") as f:
+        with open("Classes/auth.json", "w") as f:
             f.write(json.dumps({"access_token": access_token, "expires_at": time.time() + 3600}))
         print(f"{Fore.GREEN}[OpenAI][8] {Fore.WHITE}Saved access token")
 


### PR DESCRIPTION
Hi,

Found another typo in Classes path call:

```
Traceback (most recent call last):
  File "/home/alx/code/PyChatGPT/main.py", line 100, in <module>
    start_chat()
  File "/home/alx/code/PyChatGPT/main.py", line 82, in start_chat
    open_ai_auth.begin()
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 127, in begin
    self.part_two()
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 155, in part_two
    self.part_three(token=csrf_token)
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 185, in part_three
    self.part_four(url=url)
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 215, in part_four
    self.part_five(state=state)
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 265, in part_five
    self.part_six(state=state, captcha=None)
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 298, in part_six
    self.part_seven(state=state)
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 333, in part_seven
    self.part_eight(old_state=state, new_state=new_state)
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 363, in part_eight
    self.save_access_token(access_token=access_token)
  File "/home/alx/code/PyChatGPT/Classes/auth.py", line 375, in save_access_token
    with open("classes/auth.json", "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'classes/auth.json'
```

Thanks,

Alex