### PR TITLE
Update manually setting token instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ from pychatgpt import OpenAI
 OpenAI.Auth.save_access_token(access_token="", expiry=0) 
 
 # Get the token, expiry
-access_token, expiry = OpenAI.Auth.get_access_token()
+access_token, expiry = OpenAI.get_access_token()
 
 # Check if the token is valid
-is_expired = OpenAI.Auth.token_expired() # Returns True or False
+is_expired = OpenAI.token_expired() # Returns True or False
 ```
 ### Other notes
 If the token creation process is failing:


### PR DESCRIPTION
Methods get_access_token() and token_expired() are defined outside of Auth class in the latest commit. Updated README.md to reflect the change.