### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ from pychatgpt import Chat, Options
 options = Options()
 
 # [New] Enable, Disable logs
-options.logs = True
+options.log = True
 
 # Track conversation
 options.track = True 


### PR DESCRIPTION
https://github.com/rawandahmad698/PyChatGPT/blob/9db701d8a6c03ddbf9bd039dbd51396b81c1cd2c/src/pychatgpt/main.py#L23-L30

Should be `options.log` not `options.logs`