### PR TITLE
Reading from id_log

### DIFF
--- a/src/pychatgpt/main.py
+++ b/src/pychatgpt/main.py
@@ -122,7 +122,7 @@ class Chat:
             try:
                 with open(self.options.id_log, "r") as f:
                     # Check if there's any data in the file
-                    if len(f.read()) > 0:
+                    if os.path.getsize(self.options.id_log) > 0:
                         self.previous_convo_id = f.readline().strip()
                         self.conversation_id = f.readline().strip()
                     else:


### PR DESCRIPTION
https://github.com/rawandahmad698/PyChatGPT/blob/9db701d8a6c03ddbf9bd039dbd51396b81c1cd2c/src/pychatgpt/main.py#L121-L133

If using `len(f.read())` to check the file size, the whole file would be read, and `f.readline()` would return empty strings even if there are actual lines in the file.
```python3
>>> with open("test_id_log.txt", "w") as f:
...     f.write("xxxxxx-xxxxxx-xxxxxx\n")
...     f.write("yyyyyy-yyyyyy-yyyyyy\n")
... 
21
21
>>> with open("test_id_log.txt", "r") as f:
...     if len(f.read()) > 0:
...         print("Line 1: " + f.readline().strip())
...         print("Line 2: " + f.readline().strip())
... 
Line 1: 
Line 2: 
>>> 
```

I changed it to `os.path.getsize(self.options.id_log)`:
```python3
>>> with open("test_id_log.txt", "r") as f:
...     if os.path.getsize("test_id_log.txt") > 0:
...         print("Line 1: " + f.readline().strip())
...         print("Line 2: " + f.readline().strip())
... 
Line 1: xxxxxx-xxxxxx-xxxxxx
Line 2: yyyyyy-yyyyyy-yyyyyy
>>> 
```